### PR TITLE
feature(game-log): implement PO feedback on dashboard screen

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -18,6 +18,7 @@ button {
 
 ul {
   padding-left: 15px;
+  margin-top: 10px;
 }
 
 /* Global Button Styles */
@@ -396,3 +397,8 @@ footer {
   margin-top: 50px;
   margin-bottom: 0px;
   padding: 1.5rem; }
+
+.table-div {
+  height: 300px;
+  overflow: auto;
+}

--- a/public/views/dashboard.html
+++ b/public/views/dashboard.html
@@ -41,56 +41,73 @@
     <div class="container" ng-init="getData()">
         <div class="card games-section">
             <h2 class="dashboard-headers text-center">Games Played</h2>
-            <table class="table table-hover">
-            <thead>
-                <tr class="text-white bg-black">
-                  <th scope="col">#</th>
-                  <th scope="col">Owner</th>
-                  <th scope="col">Players</th>
-                  <th scope="col">Winner</th>
-                  <th scope="col">Completed</th>
-                  <th scope="col">Rounds</th>
-                </tr>
-            </thead>
-            <tbody ng-repeat="game in games">
-                <tr>
-                  <th scope="row">{{ $index + 1 }}</th>
-                  <td>{{ game.ownerUsername }}</td>
-                  <td>
-                      <ul ng-repeat="player in game.players">
-                      <li>{{ player.username }}</li>
-                      </ul>
-                  </td>
-                  <td>{{ game.winner.username || 'No Winner' }}</td>
-                  <td>{{ game.completed }}</td>
-                  <td>{{ game.rounds }}</td>
-                </tr>
-            </tbody>
-            </table>
+            <div class="table-div">
+              <table class="table table-hover">
+                <thead>
+                    <tr class="text-white bg-black">
+                      <th scope="col">#</th>
+                      <th scope="col">Owner</th>
+                      <th scope="col">Players</th>
+                      <th scope="col">Winner</th>
+                      <th scope="col">Completed</th>
+                      <th scope="col">Rounds</th>
+                    </tr>
+                </thead>
+                <tbody ng-repeat="game in games">
+                    <tr>
+                      <th scope="row">{{ $index + 1 }}</th>
+                      <td>{{ game.ownerUsername }}</td>
+                      <td>
+                        <button 
+                          class="btn btn-info" 
+                          type="button" 
+                          data-toggle="collapse" 
+                          data-target="#players{{ $index }}" 
+                          aria-expanded="false" 
+                          aria-controls="players{{ $index }}">
+                          View Players
+                        </button>
+                          <div class="collapse" id="players{{ $index }}">
+                            <ul ng-repeat="player in game.players">
+                              <li>{{ player.username }}</li>
+                            </ul>
+                          </div>
+                      </td>
+                      <td>{{ game.winner.username || 'No Winner' }}</td>
+                      <td>{{ game.completed }}</td>
+                      <td>{{ game.rounds }}</td>
+                    </tr>
+                </tbody>
+              </table>
+              <p class="ml-3" ng-if="games.length === 0">You haven't played any games.</p>
+            </div>
         </div>
 
         <div class="card leaderboard-section">
             <h2 class="dashboard-headers text-center">Leaderboard</h2>
-            <table class="table table-hover">
-            <thead>
-                <tr class="text-white bg-black">
-                  <th scope="col">Player</th>
-                  <th scope="col">Number of Wins</th>
-                </tr>
-            </thead>
-            <tbody ng-repeat="record in leaderboard">
-                <tr ng-if="record._id !== null">
-                  <td>{{ record._id }}</td>
-                  <td>{{ record.count }}</td>
-                </tr>
-            </tbody>
-            </table>
+            <div class="table-div">
+              <table class="table table-hover">
+                <thead>
+                    <tr class="text-white bg-black">
+                      <th scope="col">Player</th>
+                      <th scope="col">Number of Wins</th>
+                    </tr>
+                </thead>
+                <tbody ng-repeat="record in leaderboard">
+                    <tr ng-if="record._id">
+                      <td>{{ record._id }}</td>
+                      <td>{{ record.count }}</td>
+                    </tr>
+                </tbody>
+                </table>
+                <p class="ml-3" ng-if="leaderboard.length === 0">No Games have been played on the platform yet.</p> 
+            </div>
         </div>
 
         <div class="card donation-section">
           <h2 class="dashboard-headers text-center">Donations</h2>
           <table class="table table-hover">
-            <p class="ml-2" ng-if="donations.length === 0">Looks like you have no donations. What a shame.</p>
+            <p class="ml-3" ng-if="donations.length === 0">Looks like you have no donations. What a shame!</p>
           </table>
         </div>
     </div>


### PR DESCRIPTION
#### What does this PR do?
Implements PO feedback on dashboard page
#### Description of Task to be completed?
Implement PO feedback on dashboard page such as accordion for viewing players
#### How should this be manually tested?
* Run:
```npm run start:dev```

 * Sign up, then navigate to:
```localhost:3000/#!/```
 
 * Click Dashboard link on the main navigation

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#153741768
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-01-21 at 7 52 55 pm" src="https://user-images.githubusercontent.com/23727701/35199275-635c4c3c-fefc-11e7-9285-cc2a9d2f14cb.png">
<img width="1440" alt="screen shot 2018-01-21 at 7 52 59 pm" src="https://user-images.githubusercontent.com/23727701/35199280-701d1c26-fefc-11e7-955e-fbe825fdb73f.png">

#### Questions:
N/A